### PR TITLE
🔥 supprimer(App.scss) : supprimer les propriétés overflow-x et overfl…

### DIFF
--- a/src/scss/templates/App.scss
+++ b/src/scss/templates/App.scss
@@ -6,9 +6,6 @@
 
 // header above main slider
 #MainContent {
-    overflow-x: hidden;
-    overflow-y: hidden;
-
     .react-component-hero {
         margin-top: 60px;
     


### PR DESCRIPTION
…ow-y

Les propriétés overflow-x et overflow-y ont été supprimées car elles ne sont plus nécessaires et ne sont pas utilisées dans le code.