### PR TITLE
🚀 refactor(axios.ts) : mettre à jour l'URL de base de l'API

### DIFF
--- a/src/services/axios.ts
+++ b/src/services/axios.ts
@@ -16,7 +16,7 @@ export function updateAxiosInstance() {
     }
 
     instance = axios.create({
-        baseURL: 'https://murmuring-badlands-71376-95b0b2f10147.herokuapp.com/',
+        baseURL: 'https://murmuring-badlands-71376-95b0b2f10147.herokuapp.com/api/',
         headers: {
             'Authorization': 'Bearer ' + key
         }


### PR DESCRIPTION
L'URL de base de l'API a été mise à jour pour inclure le chemin d'accès à l'API. Cela permettra de mieux organiser les routes de l'API et de faciliter la maintenance future.