### PR TITLE
🔥 supprimer(Preloader.tsx) : supprimer l'attribut alt et breakpoint_w…

### DIFF
--- a/src/components/Preloader.tsx
+++ b/src/components/Preloader.tsx
@@ -37,8 +37,6 @@ const Preloader: React.FC<PreloaderProps> = ({ style, logo }) => {
                 <PictureImg
                     img={logo}
                     imgMobile={logo}
-                    alt="Logo"
-                    breakpoint_width="1024"
                     lazy={false}
                 />
             </div>

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -85,8 +85,6 @@ const Project: React.FC = () => {
                             <PictureImg
                                 img={image.img}
                                 imgMobile={image.imgMobile}
-                                default_size="420/430"
-                                breakpoint_width="1024"
                                 img_classes='Project__image u-rounded-border'
                             />
                         </div>

--- a/src/pages/ProjectDetails.tsx
+++ b/src/pages/ProjectDetails.tsx
@@ -1,6 +1,4 @@
 // project.tsx
-import React from 'react';
-
 const ProjectDetails = (props:any ) => {
     return (
         <div className="container section project-details">


### PR DESCRIPTION
…idth de l'élément PictureImg

L'attribut alt est supprimé car il n'est pas nécessaire dans ce contexte. L'attribut breakpoint_width est également supprimé car il n'est pas utilisé et semble être une erreur de codage.